### PR TITLE
Fix Reference layout spacing

### DIFF
--- a/src/EpcGenerator.php
+++ b/src/EpcGenerator.php
@@ -359,11 +359,12 @@ class EpcGenerator
         }
 
         if (!is_null($this->reference())) {
+            $shrink = !is_null($this->address()) ? 15 : 0;
             // Expand the image to have the reference under the diagram.
             $original_width = $image->getWidth();
             $original_height = $image->getHeight();
-            $image->resizeCanvas($original_width, ($original_height + 65), 'top', false, 'ffffff')
-                ->text('Reference: ' . $this->reference(), 15, ($original_height + 100), function ($font) {
+            $image->resizeCanvas($original_width, ($original_height + (65 - $shrink)), 'top', false, 'ffffff')
+                ->text('Reference: ' . $this->reference(), 15, ($original_height + (50 - $shrink)), function ($font) {
                     $font->file(__DIR__ . '/../assets/Arial.ttf');
                     $font->size(24);
                     $font->color('#000');


### PR DESCRIPTION
There's an issue if both reference and address are set, in that the reference is pushed outside the canvas. 

Before:
![image](https://github.com/rexlabsio/epc-generator/assets/12625062/535ab46a-0a76-45c3-8fd1-c82bdebf64f7)

After: 
![image](https://github.com/rexlabsio/epc-generator/assets/12625062/97aa1e14-dd78-440a-98d5-44f29479af20)

Other uses with fix applied
Address but no reference:
![image](https://github.com/rexlabsio/epc-generator/assets/12625062/3adce4b9-af82-4568-ad05-8aabce2f15f8)

Reference but no address:
![image](https://github.com/rexlabsio/epc-generator/assets/12625062/9b0806a5-5936-42dc-a04c-5ff24bfd1456)

No Address & no reference
![image](https://github.com/rexlabsio/epc-generator/assets/12625062/e016da81-9bf5-4205-8f57-7bc4afb75618)
